### PR TITLE
custom report filename and ability to append timestamps to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ In your `.m2/settings.xml`, configure the authentication for the maven repositor
 </servers>
 ```
 
+### Configuration
+
+If you want, you may configure certain aspects of this extension. The defaults should be fine, otherwise please create a properties file as `src/test/resources/xray-junit-extensions.properties`, and define some settings.
+
+- `report_filename`: the name of the report, without ending .xml suffix. Default is "TEST-junit-jupiter.xml"
+- `report_directory`: the directory where to generate the report, in relative or absolute format. Default is "target"
+- `add_timestamp_to_report_filename`: the name of the report, without ending .xml suffix. Default is "false".
+
+Example:
+
+```bash
+report_filename=custom-report-junit
+report_directory=reports
+add_timestamp_to_report_filename=true
+```
+
 ## How to use
 
 In order to generate the enhanced, customized JUnit XML report we need to register the **EnhancedLegacyXmlReportGeneratingListener** listener. This can be done in [several ways](https://junit.org/junit5/docs/current/user-guide/#launcher-api-listeners-custom):

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.idera.xray</groupId>
     <artifactId>xray-junit-extensions</artifactId>
     <packaging>jar</packaging>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <name>xray-junit-extensions</name>
     <url>http://maven.apache.org</url>
     <properties>

--- a/src/main/java/com/idera/xray/junit/customjunitxml/EnhancedLegacyXmlReportGeneratingListener.java
+++ b/src/main/java/com/idera/xray/junit/customjunitxml/EnhancedLegacyXmlReportGeneratingListener.java
@@ -64,12 +64,11 @@ public class EnhancedLegacyXmlReportGeneratingListener implements TestExecutionL
 
 	private XmlReportData reportData;
 
-	// For tests only
 	public EnhancedLegacyXmlReportGeneratingListener(Path reportsDir, PrintWriter out, Clock clock) {
 		this(reportsDir, null, out, clock);
 	}
 
-	// For tests only
+	// main construtor; used directly by tests
 	public EnhancedLegacyXmlReportGeneratingListener(Path reportsDir, Path propertiesFile, PrintWriter out, Clock clock) {
 		this.reportsDir = reportsDir;
 		this.propertiesFile = propertiesFile;
@@ -84,27 +83,38 @@ public class EnhancedLegacyXmlReportGeneratingListener implements TestExecutionL
 			} else {
 				// For tests only
 				stream = Files.newInputStream(propertiesFile);
-			}	
+			}
+
+			// if properties exist, or are enforced from the test, then process them
 			if (stream != null) {
 				Properties properties = new Properties();
 				properties.load(stream);
-				this.reportFilename = properties.getProperty("report_filename");
+				String customReportFilename = properties.getProperty("report_filename");
+				if (customReportFilename != null) {
+					this.reportFilename = customReportFilename;
+				}
 				String customReportsDirectory = properties.getProperty("report_directory");
 				if (customReportsDirectory != null) {
 					this.reportsDir = FileSystems.getDefault().getPath(customReportsDirectory);
 				}
 				this.addTimestampToReportFilename = "true".equals(properties.getProperty("add_timestamp_to_report_filename"));
+			} else {
+				if (reportsDir == null) {
+					this.reportsDir = FileSystems.getDefault().getPath(DEFAULT_REPORTS_DIR);
+				}
 			}
 		} catch (Exception e) {
 			//e.printStackTrace();
 		}
 	}
 
+	// service discovered automatically at runtime by JUnit
 	public EnhancedLegacyXmlReportGeneratingListener() {
 		this(FileSystems.getDefault().getPath(DEFAULT_REPORTS_DIR), new PrintWriter(System.out, true),
 				Clock.systemDefaultZone());
 	}
 
+	// used whenever registering listener programatically
 	public EnhancedLegacyXmlReportGeneratingListener(Path reportsDir, PrintWriter out) {
 		this(reportsDir, out, Clock.systemDefaultZone());
 	}

--- a/src/test/java/com/idera/xray/junit/customjunitxml/EnhancedLegacyXmlTest.java
+++ b/src/test/java/com/idera/xray/junit/customjunitxml/EnhancedLegacyXmlTest.java
@@ -45,6 +45,7 @@ import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
 import org.joox.Match;
+import org.junit.jupiter.api.Disabled;
 //import org.junit.Test;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -70,6 +71,24 @@ public class EnhancedLegacyXmlTest {
 	Path tempDirectory;
     private static final String REPORT_NAME = "TEST-junit-jupiter.xml";
 
+
+    @Test
+    @Disabled
+    public void shouldSupportCustomReportNames() throws Exception {
+        String testMethodName = "customReportNameTest";
+        executeTestMethod(TEST_EXAMPLES_CLASS, testMethodName);
+
+        String reportName = "custom-junit-report.xml";
+        Match testsuite = readValidXmlFile(tempDirectory.resolve(reportName));
+        Match testcase = testsuite.child("testcase");
+        assertThat(testcase.attr("name", String.class)).isEqualTo(testMethodName);
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "test_id")).isEmpty();
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "test_key")).isEmpty();
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "test_summary")).isEmpty();
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "test_description")).isEmpty();
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "tags")).isEmpty();
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "requirements")).isEmpty();
+    }
 
     @Test
     public void simpleTestShouldNotHaveXrayProperties() throws Exception {

--- a/src/test/java/com/idera/xray/junit/customjunitxml/XrayEnabledTestExamples.java
+++ b/src/test/java/com/idera/xray/junit/customjunitxml/XrayEnabledTestExamples.java
@@ -29,6 +29,11 @@ public class XrayEnabledTestExamples {
     }
 
     @Test
+    public void customReportNameTest() {
+    // TBD
+    }
+
+    @Test
     public void testWithTestRunComment(XrayTestReporter xrayReporter) {
         xrayReporter.addComment("hello");
 

--- a/src/test/java/com/idera/xray/junit/customjunitxml/XrayEnabledTestExamples.java
+++ b/src/test/java/com/idera/xray/junit/customjunitxml/XrayEnabledTestExamples.java
@@ -29,11 +29,6 @@ public class XrayEnabledTestExamples {
     }
 
     @Test
-    public void customReportNameTest() {
-    // TBD
-    }
-
-    @Test
     public void testWithTestRunComment(XrayTestReporter xrayReporter) {
         xrayReporter.addComment("hello");
 

--- a/src/test/resources/xray-junit-extensions.properties
+++ b/src/test/resources/xray-junit-extensions.properties
@@ -1,2 +1,3 @@
-# report_filename=custom-report-junit.xml
+# report_filename=custom-report-junit
+# report_directory=reports
 # add_timestamp_to_report_filename=true

--- a/src/test/resources/xray-junit-extensions.properties
+++ b/src/test/resources/xray-junit-extensions.properties
@@ -1,0 +1,2 @@
+# report_filename=custom-report-junit.xml
+# add_timestamp_to_report_filename=true


### PR DESCRIPTION
a PoC implementation for #11 and #14, providing configuration options for enabling custom report filename and also the ability to append a timestamp to the report filename.
For that, one needs to define a property file `src/test/resources/xray-junit-extensions.properties` with these properties:

```bash
report_filename=custom-report-junit.xml
report_directory=reports
add_timestamp_to_report_filename=true
```
