### PR TITLE
fix #33 by supporting the name attribute on ParameterizedTest annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ public class XrayEnabledTestExamples {
 
 The summary of the Test issue will be set based on these rules (the first that applies):
 
-* based on the summary attribute of @XrayTest annotation (e.g. `@XrayTest(summary = "xxx")`); 
+* based on the `summary` attribute of @XrayTest annotation (e.g. `@XrayTest(summary = "xxx")`);
+* based on the `name` attribute of `ParameterizedTest` annotation  (e.g. `@ParameterizedTest(name="{displayName}: #{index} - Test with Argument={0}")`), for parameterized tests; Inn this case, the `name` attribute can have a mention to the `DisplayName` in case the test is also annotated with it;
 * based on the `@DisplayName` annotation, or the display name of dynamically created tests from a TestFactory;
 * based on the test's method name.
 
@@ -200,6 +201,8 @@ The summary of the Test issue will be set based on these rules (the first that a
 
 For the time being, and similar to what happened with legacy JUnit XML reports produces with JUnit 4, parameterized tests (i.e. annotated with `@ParameterizedTest`) will be mapped to similar `<testcase>` elements in the JUnit XML report.
 The same happens with repeated tests (i.e annotated with `@RepeatedTest`).
+
+This will be reviewed on an upcoming version.
 
 ## Background
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>app.getxray</groupId>
     <artifactId>xray-junit-extensions</artifactId>
     <packaging>jar</packaging>
-    <version>0.6.2</version>
+    <version>0.6.3</version>
     <name>xray-junit-extensions</name>
     <description>Improvements for JUnit that allow you to take better advantage of JUnit 5 (jupiter engine) whenever using it together with Xray Test Management.</description>
     <url>https://github.com/Xray-App/xray-junit-extensions</url>

--- a/src/main/java/app/getxray/xray/junit/customjunitxml/XmlReportWriter.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/XmlReportWriter.java
@@ -12,6 +12,7 @@ package app.getxray.xray.junit.customjunitxml;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.support.AnnotationSupport;
@@ -294,17 +295,27 @@ class XmlReportWriter {
 		}
 
 		Optional<TestFactory> dynamicTest = AnnotationSupport.findAnnotation(testMethod, TestFactory.class);
+		Optional<ParameterizedTest> parameterizedTest = AnnotationSupport.findAnnotation(testMethod, ParameterizedTest.class);
 		Optional<DisplayName> displayName = AnnotationSupport.findAnnotation(testMethod, DisplayName.class);
+
+		if ( ((test_summary == null) || (test_summary.isEmpty())) && (dynamicTest.isPresent()) ) {
+			test_summary = testIdentifier.getDisplayName();
+		}
+		if ( ((test_summary == null) || (test_summary.isEmpty())) && (parameterizedTest.isPresent()) ) {
+			String customName = parameterizedTest.get().name();
+			if ((customName != null) && (!customName.isEmpty()) && (!ParameterizedTest.DEFAULT_DISPLAY_NAME.equals(customName)) ) {
+				//test_summary = customName; // unresolved, e.g. "#{index} - Test with Argument={0}"
+				test_summary = testIdentifier.getDisplayName(); // resolved name, e.g. "#2 - Test with Argument=Jimi Hendrix"
+			}
+		}
 		if ( ((test_summary == null) || (test_summary.isEmpty())) && (displayName.isPresent()) ) {
 			//test_summary = testIdentifier.getDisplayName();
 			test_summary = displayName.get().value();
 		}
-		if ( ((test_summary == null) || (test_summary.isEmpty())) && (dynamicTest.isPresent()) ) {
-			test_summary = testIdentifier.getDisplayName();
-		}
 		if ((test_summary != null) && (!test_summary.isEmpty())) {
 			addProperty(writer, "test_summary", test_summary);
 		}
+
 
 		List<String> tags = testIdentifier.getTags().stream().map(TestTag::getName).map(String::trim)
 				.collect(Collectors.toList());

--- a/src/test/java/app/getxray/xray/junit/customjunitxml/EnhancedLegacyXmlTest.java
+++ b/src/test/java/app/getxray/xray/junit/customjunitxml/EnhancedLegacyXmlTest.java
@@ -61,6 +61,7 @@ import org.junit.platform.launcher.core.LauncherFactory;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
 import app.getxray.xray.junit.customjunitxml.EnhancedLegacyXmlReportGeneratingListener;
@@ -359,9 +360,42 @@ public class EnhancedLegacyXmlTest {
         Match testsuite = readValidXmlFile(tempDirectory.resolve(REPORT_NAME));
         Match testcase = testsuite.child("testcase");
         assertThat(testcase.attr("name", String.class)).isEqualTo(testMethodName);
-        assertThat(testcase.child("properties").children("property").matchAttr("name", "test_summary")).isEmpty(); // isEqualTo("parameterizedTestWithoutDisplayName");
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "test_summary")).isEmpty();
     }
     
+
+    @Test
+    public void shouldMapNameInParameterizedTestToTestSummaryProperty() throws Exception {
+        String testMethodName = "parameterizedTestWithCustomName";
+        executeTestMethodWithParams(TEST_EXAMPLES_CLASS, testMethodName, "java.lang.String");
+        Match testsuite = readValidXmlFile(tempDirectory.resolve(REPORT_NAME));
+        assertThat(testsuite.attr("tests", int.class)).isEqualTo(2);
+        Match testcase = testsuite.children("testcase").first();
+        assertThat(testcase.attr("name", String.class)).isEqualTo(testMethodName);
+        ///assertThat(testcase.child("properties").children("property").matchAttr("name", "test_summary").attr("value")).isEqualTo("#1 - Test with Argument=John Doe");
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "test_summary").attr("value")).isEqualTo("#2 - Test with Argument=Jimi Hendrix");
+
+        Match testcase2 = testcase.next();
+        assertThat(testcase2.attr("name", String.class)).isEqualTo(testMethodName);
+        assertThat(testcase2.child("properties").children("property").matchAttr("name", "test_summary").attr("value")).isEqualTo("#1 - Test with Argument=John Doe");
+    }
+
+
+    @Test
+    public void shouldMapNameInParameterizedTestToTestSummaryProperty2() throws Exception {
+        String testMethodName = "parameterizedTestWithCustomNameAndDisplayName";
+        executeTestMethodWithParams(TEST_EXAMPLES_CLASS, testMethodName, "java.lang.String");
+        Match testsuite = readValidXmlFile(tempDirectory.resolve(REPORT_NAME));
+        assertThat(testsuite.attr("tests", int.class)).isEqualTo(2);
+        Match testcase = testsuite.children("testcase").first();
+        assertThat(testcase.attr("name", String.class)).isEqualTo(testMethodName);
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "test_summary").attr("value")).isEqualTo("custom DisplayName: #2 - Test with Argument=Jimi Hendrix");
+
+        Match testcase2 = testcase.next();
+        assertThat(testcase2.attr("name", String.class)).isEqualTo(testMethodName);
+        assertThat(testcase2.child("properties").children("property").matchAttr("name", "test_summary").attr("value")).isEqualTo("custom DisplayName: #1 - Test with Argument=John Doe");
+    }
+
 
     @Test
     public void shouldMapDisplayNameInRepeatedTestToTestSummaryProperty() throws Exception {

--- a/src/test/java/app/getxray/xray/junit/customjunitxml/XrayEnabledTestExamples.java
+++ b/src/test/java/app/getxray/xray/junit/customjunitxml/XrayEnabledTestExamples.java
@@ -136,6 +136,21 @@ public class XrayEnabledTestExamples {
         fail("without DisplayName");
     }
 
+    @ParameterizedTest(name="#{index} - Test with Argument={0}")
+    @ValueSource(strings = {"John Doe", "Jimi Hendrix"})
+    public void parameterizedTestWithCustomName(String name)
+    {
+        fail("test failed on purpose");
+    }
+
+    @DisplayName("custom DisplayName")
+    @ParameterizedTest(name="{displayName}: #{index} - Test with Argument={0}")
+    @ValueSource(strings = {"John Doe", "Jimi Hendrix"})
+    public void parameterizedTestWithCustomNameAndDisplayName(String name)
+    {
+        fail("test failed on purpose");
+    }
+
     @DisplayName("custom name")
     @RepeatedTest(3)
     void repeatedTestAnnotatedWithDisplayName() {


### PR DESCRIPTION
Add a preliminary fix to support parameterized tests annotated with a custom name `@ParameterizedTest(name="...")`