### PR TITLE
Abstraction for reading test metadata added

### DIFF
--- a/src/main/java/app/getxray/xray/junit/customjunitxml/DefaultXrayTestMetadataReader.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/DefaultXrayTestMetadataReader.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package app.getxray.xray.junit.customjunitxml;
+
+import app.getxray.xray.junit.customjunitxml.annotations.Requirement;
+import app.getxray.xray.junit.customjunitxml.annotations.XrayTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestIdentifier;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class DefaultXrayTestMetadataReader implements XrayTestMetadataReader {
+
+    @Override
+    public Optional<String> getId(TestIdentifier testIdentifier) {
+        return getTestMethodAnnotation(testIdentifier, XrayTest.class)
+                .map(XrayTest::id)
+                .filter(s -> !s.isEmpty());
+    }
+
+    @Override
+    public Optional<String> getKey(TestIdentifier testIdentifier) {
+        return getTestMethodAnnotation(testIdentifier, XrayTest.class)
+                .map(XrayTest::key)
+                .filter(s -> !s.isEmpty());
+    }
+
+    @Override
+    public Optional<String> getSummary(TestIdentifier testIdentifier) {
+        Optional<String> testSummary = getTestMethodAnnotation(testIdentifier, XrayTest.class)
+                .map(XrayTest::summary)
+                .filter(s -> !s.isEmpty());
+        if (testSummary.isPresent()) {
+            return testSummary;
+        }
+
+        Optional<DisplayName> displayName = getTestMethodAnnotation(testIdentifier, DisplayName.class);
+        if (displayName.isPresent()) {
+            return Optional.of(displayName.get().value());
+        }
+
+
+        Optional<TestFactory> dynamicTest = getTestMethodAnnotation(testIdentifier, TestFactory.class);
+        Optional<DisplayNameGeneration> displayNameGenerator = getTestClassAnnotation(testIdentifier, DisplayNameGeneration.class);
+        if (dynamicTest.isPresent() || displayNameGenerator.isPresent()) {
+            return Optional.of(testIdentifier.getDisplayName());
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> getDescription(TestIdentifier testIdentifier) {
+        return getTestMethodAnnotation(testIdentifier, XrayTest.class)
+                .map(XrayTest::description)
+                .filter(s -> !s.isEmpty());
+    }
+
+    @Override
+    public List<String> getRequirements(TestIdentifier testIdentifier) {
+        return getTestMethodAnnotation(testIdentifier, Requirement.class)
+                .map(Requirement::value)
+                .map(arr -> Collections.unmodifiableList(Arrays.asList(arr)))
+                .orElse(Collections.emptyList());
+    }
+
+    protected <A extends Annotation> Optional<A> getTestMethodAnnotation(TestIdentifier testIdentifier, Class<A> aClass) {
+        return testIdentifier.getSource()
+                .filter(a -> a instanceof MethodSource)
+                .map(MethodSource.class::cast)
+                .map(MethodSource::getJavaMethod)
+                .flatMap(a -> AnnotationSupport.findAnnotation(a, aClass));
+    }
+
+    protected <A extends Annotation> Optional<A> getTestClassAnnotation(TestIdentifier testIdentifier, Class<A> aClass) {
+        return testIdentifier.getSource()
+                .filter(a -> a instanceof MethodSource)
+                .map(MethodSource.class::cast)
+                .map(MethodSource::getJavaClass)
+                .flatMap(a -> AnnotationSupport.findAnnotation(a, aClass));
+    }
+}

--- a/src/main/java/app/getxray/xray/junit/customjunitxml/XmlReportWriter.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/XmlReportWriter.java
@@ -10,9 +10,6 @@
 
 package app.getxray.xray.junit.customjunitxml;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.TestFactory;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.support.AnnotationSupport;
@@ -96,14 +93,19 @@ class XmlReportWriter {
 	// re-add separator characters.
 	private static final Pattern CDATA_SPLIT_PATTERN = Pattern.compile("(?<=]])(?=>)");
 
-	private final XmlReportData reportData;
-	private static final Logger logger = LoggerFactory.getLogger(EnhancedLegacyXmlReportGeneratingListener.class);
-	private boolean reportOnlyAnnotatedTests = false;
+    private static final Logger logger = LoggerFactory.getLogger(EnhancedLegacyXmlReportGeneratingListener.class);
 
-	XmlReportWriter(XmlReportData reportData, boolean reportOnlyAnnotatedTests) {
-		this.reportData = reportData;
+    private final XmlReportData reportData;
+	private final boolean reportOnlyAnnotatedTests;
+	private final XrayTestMetadataReader xrayTestMetadataReader;
+
+    XmlReportWriter(XmlReportData reportData,
+                    boolean reportOnlyAnnotatedTests,
+                    XrayTestMetadataReader xrayTestMetadataReader) {
+        this.reportData = reportData;
 		this.reportOnlyAnnotatedTests = reportOnlyAnnotatedTests;
-	}
+        this.xrayTestMetadataReader = xrayTestMetadataReader;
+    }
 
 	void writeXmlReport(TestIdentifier rootDescriptor, Writer out) throws XMLStreamException {
 		TestPlan testPlan = this.reportData.getTestPlan();
@@ -234,7 +236,6 @@ class XmlReportWriter {
 
 		final Optional<TestSource> testSource = testIdentifier.getSource();
 		final Optional<Method> testMethod = testSource.flatMap(this::getTestMethod);
-		final Class testClass = ((MethodSource)testSource.get()).getJavaClass();
 		Optional<XrayTest> xrayTest = AnnotationSupport.findAnnotation(testMethod, XrayTest.class);
 		Optional<Requirement> requirement = AnnotationSupport.findAnnotation(testMethod, Requirement.class);
 		if (reportOnlyAnnotatedTests && (!requirement.isPresent() && !xrayTest.isPresent())) {
@@ -272,49 +273,28 @@ class XmlReportWriter {
 			newLine(writer);
 		}
 
-		// final Optional<Class<?>> testClass = testSource.flatMap(this::getTestClass);
-
-		if (requirement.isPresent()) {
-			String[] requirements = requirement.get().value();
+		List<String> requirements = xrayTestMetadataReader.getRequirements(testIdentifier);
+		if (!requirements.isEmpty()) {
 			addProperty(writer, "requirements", String.join(",", requirements));
 		}
 
-		String test_key = null;
-		String test_id = null;
-		String test_summary = null;
-		String test_description = null;
-		if (xrayTest.isPresent()) {
-			test_key = xrayTest.get().key();
-			if ((test_key != null) && (!test_key.isEmpty())) {
-				addProperty(writer, "test_key", test_key);
-			}
+        Optional<String> test_key = xrayTestMetadataReader.getKey(testIdentifier);
+        if (test_key.isPresent()) {
+            addProperty(writer, "test_key", test_key.get());
+        }
+        Optional<String> test_id = xrayTestMetadataReader.getId(testIdentifier);
+        if (test_id.isPresent()) {
+            addProperty(writer, "test_id", test_id.get());
+        }
 
-			test_id = xrayTest.get().id();
-			if ((test_id != null) && (!test_id.isEmpty())) {
-				addProperty(writer, "test_id", test_id);
-			}
+        Optional<String> test_description = xrayTestMetadataReader.getDescription(testIdentifier);
+        if (test_description.isPresent()) {
+            addPropertyWithInnerContent(writer, "test_description", test_description.get());
+        }
 
-			test_summary = xrayTest.get().summary();
-			test_description = xrayTest.get().description();
-			if ((test_description != null) && (!test_description.isEmpty())) {
-				addPropertyWithInnerContent(writer, "test_description", test_description);
-			}
-		}
-
-		Optional<TestFactory> dynamicTest = AnnotationSupport.findAnnotation(testMethod, TestFactory.class);
-		Optional<DisplayName> displayName = AnnotationSupport.findAnnotation(testMethod, DisplayName.class);
-		Optional<DisplayNameGeneration> displayNameGenerator = AnnotationSupport.findAnnotation(testClass, DisplayNameGeneration.class);
-
-		// this logic should be improved/simplified; the displayNameGererator logic isnt handling all cases, inclusing if it was set globally
-		if ( ((test_summary == null) || (test_summary.isEmpty())) && (displayName.isPresent()) ) {
-			test_summary = displayName.get().value();
-		}
-		if ( ((test_summary == null) || (test_summary.isEmpty())) && (dynamicTest.isPresent() || displayNameGenerator.isPresent()) ) {
-			test_summary = testIdentifier.getDisplayName();
-		}
-
-		if ((test_summary != null) && (!test_summary.isEmpty())) {
-			addProperty(writer, "test_summary", test_summary);
+        Optional<String> test_summary = xrayTestMetadataReader.getSummary(testIdentifier);
+		if (test_summary.isPresent()) {
+			addProperty(writer, "test_summary", test_summary.get());
 		}
 
 		List<String> tags = testIdentifier.getTags().stream().map(TestTag::getName).map(String::trim)

--- a/src/main/java/app/getxray/xray/junit/customjunitxml/XrayTestMetadataReader.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/XrayTestMetadataReader.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package app.getxray.xray.junit.customjunitxml;
+
+import org.junit.platform.launcher.TestIdentifier;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface XrayTestMetadataReader {
+
+    /**
+     * @param testIdentifier test identifier
+     * @return test id if any or empty
+     */
+    Optional<String> getId(TestIdentifier testIdentifier);
+
+    /**
+     * @param testIdentifier test identifier
+     * @return test key if any
+     */
+    Optional<String> getKey(TestIdentifier testIdentifier);
+
+    /**
+     * @param testIdentifier test identifier
+     * @return test summary if any
+     */
+    Optional<String> getSummary(TestIdentifier testIdentifier);
+
+    /**
+     * @param testIdentifier test identifier
+     * @return test description if any
+     */
+    Optional<String> getDescription(TestIdentifier testIdentifier);
+
+    /**
+     * @param testIdentifier test identifier
+     * @return Unmodifiable list of requirements
+     */
+    List<String> getRequirements(TestIdentifier testIdentifier);
+
+}

--- a/src/test/java/app/getxray/xray/junit/customjunitxml/CustomXrayTestMetadataReader.java
+++ b/src/test/java/app/getxray/xray/junit/customjunitxml/CustomXrayTestMetadataReader.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package app.getxray.xray.junit.customjunitxml;
+
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestIdentifier;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class CustomXrayTestMetadataReader implements XrayTestMetadataReader {
+    @Override
+    public Optional<String> getId(TestIdentifier testIdentifier) {
+        return testIdentifier.getSource()
+                .map(MethodSource.class::cast)
+                .map(MethodSource::getJavaMethod)
+                .map(Method::getName)
+                .map(a -> "ID:" + a);
+    }
+
+    @Override
+    public Optional<String> getKey(TestIdentifier testIdentifier) {
+        return testIdentifier.getSource()
+                .map(MethodSource.class::cast)
+                .map(MethodSource::getJavaMethod)
+                .map(Method::getName)
+                .map(a -> "KEY:" + a);
+    }
+
+    @Override
+    public Optional<String> getSummary(TestIdentifier testIdentifier) {
+        return testIdentifier.getSource()
+                .map(MethodSource.class::cast)
+                .map(MethodSource::getJavaMethod)
+                .map(Method::getName)
+                .map(a -> "SUMMARY:" + a);
+    }
+
+    @Override
+    public Optional<String> getDescription(TestIdentifier testIdentifier) {
+        return testIdentifier.getSource()
+                .map(MethodSource.class::cast)
+                .map(MethodSource::getJavaMethod)
+                .map(Method::getName)
+                .map(a -> "DESCRIPTION:" + a);
+    }
+
+    @Override
+    public List<String> getRequirements(TestIdentifier testIdentifier) {
+        return Collections.emptyList();
+    }
+}

--- a/src/test/java/app/getxray/xray/junit/customjunitxml/DefaultXrayTestInfoReaderTest.java
+++ b/src/test/java/app/getxray/xray/junit/customjunitxml/DefaultXrayTestInfoReaderTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package app.getxray.xray.junit.customjunitxml;
+
+import app.getxray.xray.junit.customjunitxml.data.MockedTestClass;
+import app.getxray.xray.junit.customjunitxml.data.MockedTestWithDisplayNameGeneratorClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
+import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.platform.engine.ConfigurationParameters;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.launcher.TestIdentifier;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultXrayTestInfoReaderTest {
+
+    private final XrayTestMetadataReader xrayTestMetadataReader = new DefaultXrayTestMetadataReader();
+    private static TestDescriptor XRAYTEST_ANNOTATED;
+    private static TestDescriptor XRAYTEST_EMPTY_ANNOTATION;
+    private static TestDescriptor NOT_ANNOTATED;
+    private static TestDescriptor DISPLAY_NAME_ANNOTATED;
+    private static TestDescriptor XRAYTEST_AND_DISPLAY_NAME_ANNOTATED;
+    private static TestDescriptor WITH_DISPLAY_NAME_GENERATOR;
+    private static TestDescriptor WITH_TEST_FACTORY;
+
+    @BeforeAll
+    static void setUp() throws NoSuchMethodException {
+        JupiterConfiguration jupiterConfiguration = new DefaultJupiterConfiguration(
+                new ConfigurationParameters() {
+                    @Override
+                    public Optional<String> get(String key) {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public Optional<Boolean> getBoolean(String key) {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public int size() {
+                        return 0;
+                    }
+
+                    @Override
+                    public Set<String> keySet() {
+                        return Collections.emptySet();
+                    }
+                }
+        );
+
+        XRAYTEST_ANNOTATED = new TestMethodTestDescriptor(
+                UniqueId.forEngine("foo"),
+                MockedTestClass.class,
+                MockedTestClass.class.getMethod("annotatedWithValues"),
+                jupiterConfiguration
+        );
+        XRAYTEST_EMPTY_ANNOTATION = new TestMethodTestDescriptor(
+                UniqueId.forEngine("foo"),
+                MockedTestClass.class,
+                MockedTestClass.class.getMethod("annotatedWithEmptyValues"),
+                jupiterConfiguration
+        );
+        NOT_ANNOTATED = new TestMethodTestDescriptor(
+                UniqueId.forEngine("foo"),
+                MockedTestClass.class,
+                MockedTestClass.class.getMethod("notAnnotatedTest"),
+                jupiterConfiguration
+        );
+        DISPLAY_NAME_ANNOTATED = new TestMethodTestDescriptor(
+                UniqueId.forEngine("foo"),
+                MockedTestClass.class,
+                MockedTestClass.class.getMethod("annotatedWithDisplayName"),
+                jupiterConfiguration
+        );
+        XRAYTEST_AND_DISPLAY_NAME_ANNOTATED = new TestMethodTestDescriptor(
+                UniqueId.forEngine("foo"),
+                MockedTestClass.class,
+                MockedTestClass.class.getMethod("annotatedWithXrayTestAndDisplayName"),
+                jupiterConfiguration
+        );
+        WITH_DISPLAY_NAME_GENERATOR = new TestMethodTestDescriptor(
+                UniqueId.forEngine("foo"),
+                MockedTestWithDisplayNameGeneratorClass.class,
+                MockedTestWithDisplayNameGeneratorClass.class.getMethod("withDisplayNameGenerator"),
+                jupiterConfiguration
+        );
+        WITH_TEST_FACTORY = new TestMethodTestDescriptor(
+                UniqueId.forEngine("foo"),
+                MockedTestClass.class,
+                MockedTestClass.class.getMethod("withTestFactory"),
+                jupiterConfiguration
+        );
+    }
+
+    @Test
+    void shouldReturnKeyFromXrayTestAnnotation() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_ANNOTATED);
+        // WHEN
+        Optional<String> keyOpt = xrayTestMetadataReader.getKey(testIdentifier);
+        // THEN
+        assertThat(keyOpt)
+                .contains("ABC-123");
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyFromXrayTestAnnotationWithEmptyKey() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_EMPTY_ANNOTATION);
+        // WHEN
+        Optional<String> keyOpt = xrayTestMetadataReader.getKey(testIdentifier);
+        // THEN
+        assertThat(keyOpt)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyKeyWhenMethodNotAnnotated() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(NOT_ANNOTATED);
+        // WHEN
+        Optional<String> keyOpt = xrayTestMetadataReader.getKey(testIdentifier);
+        // THEN
+        assertThat(keyOpt)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldReturnIdFromXrayTestAnnotation() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_ANNOTATED);
+        // WHEN
+        Optional<String> idOpt = xrayTestMetadataReader.getId(testIdentifier);
+        // THEN
+        assertThat(idOpt)
+                .contains("868");
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyFromXrayTestAnnotationWithEmptyId() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_EMPTY_ANNOTATION);
+        // WHEN
+        Optional<String> idOpt = xrayTestMetadataReader.getId(testIdentifier);
+        // THEN
+        assertThat(idOpt)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyIdWhenMethodNotAnnotated() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(NOT_ANNOTATED);
+        // WHEN
+        Optional<String> idOpt = xrayTestMetadataReader.getId(testIdentifier);
+        // THEN
+        assertThat(idOpt)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldReturnSummaryFromXrayTestAnnotation() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_ANNOTATED);
+        // WHEN
+        Optional<String> summaryOpt = xrayTestMetadataReader.getSummary(testIdentifier);
+        // THEN
+        assertThat(summaryOpt)
+                .contains("some summary");
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyFromXrayTestAnnotationWithEmptySummary() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_EMPTY_ANNOTATION);
+        // WHEN
+        Optional<String> summaryOpt = xrayTestMetadataReader.getSummary(testIdentifier);
+        // THEN
+        assertThat(summaryOpt)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldReturnOptionalEmptySummaryWhenMethodNotAnnotated() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(NOT_ANNOTATED);
+        // WHEN
+        Optional<String> summaryOpt = xrayTestMetadataReader.getSummary(testIdentifier);
+        // THEN
+        assertThat(summaryOpt)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldReturnDisplayNameWhenNotAnnotatedWithXrayTest() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(DISPLAY_NAME_ANNOTATED);
+        // WHEN
+        Optional<String> summaryOpt = xrayTestMetadataReader.getSummary(testIdentifier);
+        // THEN
+        assertThat(summaryOpt)
+                .contains("display name");
+    }
+
+    @Test
+    void shouldReturnDisplayNameFromXrayTestAnnotationWhenAlsoAnnotatedWithDisplayName() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_AND_DISPLAY_NAME_ANNOTATED);
+        // WHEN
+        Optional<String> summaryOpt = xrayTestMetadataReader.getSummary(testIdentifier);
+        // THEN
+        assertThat(summaryOpt)
+                .contains("xray summary");
+    }
+
+    @Test
+    void shouldReturnDefaultDisplayNameWhenAnnotatedWithDisplayNameGenerator() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(WITH_DISPLAY_NAME_GENERATOR);
+        // WHEN
+        Optional<String> summaryOpt = xrayTestMetadataReader.getSummary(testIdentifier);
+        // THEN
+        assertThat(summaryOpt)
+                .contains("DisplayNameForMethod");
+    }
+
+    @Test
+    void shouldReturnDefaultDisplayNameWhenAnnotatedWithTestFactory() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(WITH_TEST_FACTORY);
+        // WHEN
+        Optional<String> summaryOpt = xrayTestMetadataReader.getSummary(testIdentifier);
+        // THEN
+        assertThat(summaryOpt)
+                .contains("withTestFactory()");
+    }
+
+    @Test
+    void shouldReturnDescriptionFromXrayTestAnnotation() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_ANNOTATED);
+        // WHEN
+        Optional<String> descriptionOpt = xrayTestMetadataReader.getDescription(testIdentifier);
+        // THEN
+        assertThat(descriptionOpt)
+                .contains("some description");
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyFromXrayTestAnnotationWithEmptyDescription() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_EMPTY_ANNOTATION);
+        // WHEN
+        Optional<String> descriptionOpt = xrayTestMetadataReader.getDescription(testIdentifier);
+        // THEN
+        assertThat(descriptionOpt)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyDescriptionWhenMethodNotAnnotated() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(NOT_ANNOTATED);
+        // WHEN
+        Optional<String> descriptionOpt = xrayTestMetadataReader.getDescription(testIdentifier);
+        // THEN
+        assertThat(descriptionOpt)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldReturnRequirementsFromRequirementsAnnotation() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_ANNOTATED);
+        // WHEN
+        List<String> requirements = xrayTestMetadataReader.getRequirements(testIdentifier);
+        // THEN
+        assertThat(requirements)
+                .containsExactly("REQ-1", "REQ-2");
+    }
+
+    @Test
+    void shouldReturnEmptyListFromRequirementsAnnotationWithEmptyArray() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(XRAYTEST_EMPTY_ANNOTATION);
+        // WHEN
+        List<String> requirements = xrayTestMetadataReader.getRequirements(testIdentifier);
+        // THEN
+        assertThat(requirements)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyListOfRequirementsWhenMethodNotAnnotated() {
+        // GIVEN
+        TestIdentifier testIdentifier = TestIdentifier.from(NOT_ANNOTATED);
+        // WHEN
+        List<String> requirements = xrayTestMetadataReader.getRequirements(testIdentifier);
+        // THEN
+        assertThat(requirements)
+                .isEmpty();
+    }
+}

--- a/src/test/java/app/getxray/xray/junit/customjunitxml/EnhancedLegacyXmlTest.java
+++ b/src/test/java/app/getxray/xray/junit/customjunitxml/EnhancedLegacyXmlTest.java
@@ -104,6 +104,42 @@ public class EnhancedLegacyXmlTest {
         assertThat(testsuite.children("testcase").matchAttr("name", "anotherSimpleTest")).isNotEmpty();
     }
 
+    @Test
+    public void shouldUseCustomMetadataReader() throws Exception {
+        String customProperties = "test_metadata_reader=" + CustomXrayTestMetadataReader.class.getName() + "\n";
+        Path customPropertiesFile = Files.createTempFile("xray-junit-extensions", ".properties");
+        Files.write(customPropertiesFile, customProperties.getBytes());
+
+        executeTestClasses(new Class[]{BASIC_CLASS}, customPropertiesFile, Clock.systemDefaultZone());
+
+        String reportName = "TEST-junit-jupiter.xml";
+        Match testsuite = readValidXmlFile(tempDirectory.resolve(reportName));
+        assertThat(testsuite.children("testcase")).hasSize(2);
+
+        Match someBasicTestTestCase = testsuite.children("testcase").matchAttr("name", "someBasicTest");
+        assertThat(someBasicTestTestCase).isNotEmpty();
+        Match someBasicTestTestCaseProps = someBasicTestTestCase.children("properties").children("property");
+        assertThat(someBasicTestTestCaseProps.matchAttr("name", "test_id").attr("value"))
+                .isEqualTo("ID:someBasicTest");
+        assertThat(someBasicTestTestCaseProps.matchAttr("name", "test_key").attr("value"))
+                .isEqualTo("KEY:someBasicTest");
+        assertThat(someBasicTestTestCaseProps.matchAttr("name", "test_summary").attr("value"))
+                .isEqualTo("SUMMARY:someBasicTest");
+        assertThat(someBasicTestTestCaseProps.matchAttr("name", "test_description").text())
+                .isEqualTo("DESCRIPTION:someBasicTest");
+
+        Match anotherBasicTestTestCase = testsuite.children("testcase").matchAttr("name", "anotherBasicTest");
+        assertThat(anotherBasicTestTestCase).isNotEmpty();
+        Match anotherBasicTestTestCaseProps = anotherBasicTestTestCase.children("properties").children("property");
+        assertThat(anotherBasicTestTestCaseProps.matchAttr("name", "test_id").attr("value"))
+                .isEqualTo("ID:anotherBasicTest");
+        assertThat(anotherBasicTestTestCaseProps.matchAttr("name", "test_key").attr("value"))
+                .isEqualTo("KEY:anotherBasicTest");
+        assertThat(anotherBasicTestTestCaseProps.matchAttr("name", "test_summary").attr("value"))
+                .isEqualTo("SUMMARY:anotherBasicTest");
+        assertThat(anotherBasicTestTestCaseProps.matchAttr("name", "test_description").text())
+                .isEqualTo("DESCRIPTION:anotherBasicTest");
+    }
 
     @Test
     public void shouldSupportCustomReportNames() throws Exception {

--- a/src/test/java/app/getxray/xray/junit/customjunitxml/data/MockedTestClass.java
+++ b/src/test/java/app/getxray/xray/junit/customjunitxml/data/MockedTestClass.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package app.getxray.xray.junit.customjunitxml.data;
+
+import app.getxray.xray.junit.customjunitxml.annotations.Requirement;
+import app.getxray.xray.junit.customjunitxml.annotations.XrayTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestFactory;
+
+@Disabled
+public class MockedTestClass {
+
+    @XrayTest(
+            key = "ABC-123",
+            id = "868",
+            summary = "some summary",
+            description = "some description"
+    )
+    @Requirement({"REQ-1", "REQ-2"})
+    public void annotatedWithValues() {
+
+    }
+
+    @XrayTest
+    @Requirement({})
+    public void annotatedWithEmptyValues() {
+
+    }
+
+    public void notAnnotatedTest() {
+
+    }
+
+    @DisplayName("display name")
+    public void annotatedWithDisplayName() {
+
+    }
+
+    @XrayTest(summary = "xray summary")
+    @DisplayName("display name")
+    public void annotatedWithXrayTestAndDisplayName() {
+
+    }
+
+    @TestFactory
+    public void withTestFactory() {
+
+    }
+}

--- a/src/test/java/app/getxray/xray/junit/customjunitxml/data/MockedTestWithDisplayNameGeneratorClass.java
+++ b/src/test/java/app/getxray/xray/junit/customjunitxml/data/MockedTestWithDisplayNameGeneratorClass.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package app.getxray.xray.junit.customjunitxml.data;
+
+import app.getxray.xray.junit.customjunitxml.annotations.XrayTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+import java.lang.reflect.Method;
+
+@Disabled
+@DisplayNameGeneration(MockedTestWithDisplayNameGeneratorClass.CustomGenerator.class)
+public class MockedTestWithDisplayNameGeneratorClass {
+
+    public static class CustomGenerator implements DisplayNameGenerator {
+        @Override
+        public String generateDisplayNameForClass(Class<?> testClass) {
+            return "DisplayNameForClass";
+        }
+
+        @Override
+        public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+            return "DisplayNameForNestedClass";
+        }
+
+        @Override
+        public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+            return "DisplayNameForMethod";
+        }
+    }
+
+    @XrayTest()
+    public void withDisplayNameGenerator() {
+
+    }
+
+}


### PR DESCRIPTION
As discussed in #54, an abstraction for reading test info added.

In this PR:

- A new public interface `XrayTestMetadataReader` added
- A default implementation of `XrayTestMetadataReader` - `CustomXrayTestMetadataReader` added
- reading value of `XrayTestMetadataReader` from `xray-junit-extensions.properties` added
- JUnit5 tests added