### PR TITLE
Handle fail in the static initializer

### DIFF
--- a/src/main/java/app/getxray/xray/junit/customjunitxml/XmlReportWriter.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/XmlReportWriter.java
@@ -210,7 +210,7 @@ class XmlReportWriter {
 			final Class<?> aClass = Class.forName(source.getClassName());
 			return Stream.of(aClass.getDeclaredMethods()).filter(method -> MethodSource.from(method).equals(source))
 					.findAny();
-		} catch (ClassNotFoundException e) {
+		} catch (ClassNotFoundException | NoClassDefFoundError e) {
 			logger.error(e, () -> "Could not get test method from method source " + source);
 		}
 		return Optional.empty();


### PR DESCRIPTION
Hello,

This is a small fix for the edge case.

## Problem

If an error occurs during the initialization of the class, then the report will be incomplete.

Let's set up this test code:
```java
import org.junit.jupiter.api.Test;

class AbcTest {

  static final String TEST_STRING = getTestString();

  private static String getTestString() {
    throw new RuntimeException();
  }

  @Test
  void test() {
  }
}
```

This will generate the following incomplete test result report:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="JUnit Jupiter" tests="1" skipped="0" failures="0" errors="1" time="0" hostname="DESKTOP-XXXXXX" timestamp="2024-11-20T17:32:39">
<properties>
<property name="debugger.agent.enable.coroutines" value="true"/>
<property name="file.encoding" value="UTF-8"/>
<property name="file.separator" value="\"/>
<property name="idea.test.cyclic.buffer.size" value="1048576"/>
<property name="intellij.debug.agent" value="true"/>
<!-- skipped entries containing system details -->
<property name="user.script" value=""/>
<property name="user.timezone" value="Europe/Warsaw"/>
<property name="user.variant" value=""/>
</properties>

```

After my changes the report file will be valid:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="JUnit Jupiter" tests="1" skipped="0" failures="0" errors="1" time="0" hostname="DESKTOP-XXXXXX" timestamp="2024-11-20T17:39:05">
<properties>
<property name="debugger.agent.enable.coroutines" value="true"/>
<property name="file.encoding" value="UTF-8"/>
<property name="file.separator" value="\"/>
<property name="idea.test.cyclic.buffer.size" value="1048576"/>
<property name="intellij.debug.agent" value="true"/>
<!-- skipped entries containing system details -->
<property name="user.script" value=""/>
<property name="user.timezone" value="Europe/Warsaw"/>
<property name="user.variant" value=""/>
</properties>
<testcase name="test" classname="AbcTest" time="0" started-at="2024-11-20T16:39:05.3231165" finished-at="2024-11-20T16:39:05.3440692">
<error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1160)
	at java.base/java.lang.reflect.Constructor.acquireConstructorAccessor(Constructor.java:549)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
Caused by: java.lang.RuntimeException
	at AbcTest.getTestString(AbcTest.java:8)
	at AbcTest.<clinit>(AbcTest.java:5)
	... 8 more
]]></error>
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:AbcTest]/[method:test()]
display-name: test()
]]></system-out>
<properties>
<property name="_dummy_" value=""/>
</properties>
</testcase>
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]
display-name: JUnit Jupiter
]]></system-out>
</testsuite>
```