### PR TITLE
Dynamic test support

### DIFF
--- a/src/main/java/app/getxray/xray/junit/customjunitxml/DefaultXrayTestMetadataReader.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/DefaultXrayTestMetadataReader.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.engine.support.descriptor.UriSource;
 import org.junit.platform.launcher.TestIdentifier;
 
 import java.lang.annotation.Annotation;
@@ -29,16 +30,36 @@ public class DefaultXrayTestMetadataReader implements XrayTestMetadataReader {
 
     @Override
     public Optional<String> getId(TestIdentifier testIdentifier) {
-        return getTestMethodAnnotation(testIdentifier, XrayTest.class)
+        Optional<String> id = getTestMethodAnnotation(testIdentifier, XrayTest.class)
                 .map(XrayTest::id)
                 .filter(s -> !s.isEmpty());
+        if (id.isPresent()) {
+            return id;
+        }
+
+        Optional<String> uriSourceId = readQueryValue(testIdentifier, XrayURI.QUERY_ID);
+        if (uriSourceId.isPresent()) {
+            return uriSourceId;
+        }
+
+        return Optional.empty();
     }
 
     @Override
     public Optional<String> getKey(TestIdentifier testIdentifier) {
-        return getTestMethodAnnotation(testIdentifier, XrayTest.class)
+        Optional<String> key = getTestMethodAnnotation(testIdentifier, XrayTest.class)
                 .map(XrayTest::key)
                 .filter(s -> !s.isEmpty());
+        if (key.isPresent()) {
+            return key;
+        }
+
+        Optional<String> uriSourceKey = readQueryValue(testIdentifier, XrayURI.QUERY_KEY);
+        if (uriSourceKey.isPresent()) {
+            return uriSourceKey;
+        }
+
+        return Optional.empty();
     }
 
     @Override
@@ -62,14 +83,29 @@ public class DefaultXrayTestMetadataReader implements XrayTestMetadataReader {
             return Optional.of(testIdentifier.getDisplayName());
         }
 
+        Optional<String> uriSourceSummary = readQueryValue(testIdentifier, XrayURI.QUERY_SUMMARY);
+        if (uriSourceSummary.isPresent()) {
+            return uriSourceSummary;
+        }
+
         return Optional.empty();
     }
 
     @Override
     public Optional<String> getDescription(TestIdentifier testIdentifier) {
-        return getTestMethodAnnotation(testIdentifier, XrayTest.class)
+        Optional<String> description = getTestMethodAnnotation(testIdentifier, XrayTest.class)
                 .map(XrayTest::description)
                 .filter(s -> !s.isEmpty());
+        if (description.isPresent()) {
+            return description;
+        }
+
+        Optional<String> uriSourceDescription = readQueryValue(testIdentifier, XrayURI.QUERY_DESCRIPTION);
+        if (uriSourceDescription.isPresent()) {
+            return uriSourceDescription;
+        }
+
+        return Optional.empty();
     }
 
     @Override
@@ -94,5 +130,13 @@ public class DefaultXrayTestMetadataReader implements XrayTestMetadataReader {
                 .map(MethodSource.class::cast)
                 .map(MethodSource::getJavaClass)
                 .flatMap(a -> AnnotationSupport.findAnnotation(a, aClass));
+    }
+
+    private Optional<String> readQueryValue(TestIdentifier testIdentifier, String key) {
+        return testIdentifier.getSource()
+                .filter(UriSource.class::isInstance)
+                .map(UriSource.class::cast)
+                .map(UriSource::getUri)
+                .flatMap(x -> XrayURI.readQueryValue(x, key));
     }
 }

--- a/src/main/java/app/getxray/xray/junit/customjunitxml/XrayURI.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/XrayURI.java
@@ -1,0 +1,96 @@
+package app.getxray.xray.junit.customjunitxml;
+
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class XrayURI {
+
+    protected static final String QUERY_ID = "id";
+    protected static final String QUERY_KEY = "key";
+    protected static final String QUERY_SUMMARY = "summary";
+    protected static final String QUERY_DESCRIPTION = "description";
+
+    private XrayURI() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    protected static Optional<String> readQueryValue(URI uri, String key) {
+        String query = uri.getQuery();
+        if (query == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(query.split("&"))
+                .filter(p -> p.startsWith(key + "="))
+                .map(p -> p.substring(key.length() + 1))
+                .map(value -> {
+                    try {
+                        return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+                    } catch (UnsupportedEncodingException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                })
+                .findFirst();
+    }
+
+    public static class Builder {
+        private String id;
+        private String key;
+        private String summary;
+        private String description;
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder key(String key) {
+            this.key = key;
+            return this;
+        }
+
+        public Builder summary(String summary) {
+            this.summary = summary;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public URI build(Class<?> testClass) {
+            List<String> query = new ArrayList<>();
+            try {
+                if (id != null) {
+                    query.add(QUERY_ID + "=" + URLEncoder.encode(id, StandardCharsets.UTF_8.name()));
+                }
+                if (key != null) {
+                    query.add(QUERY_KEY + "=" + URLEncoder.encode(key, StandardCharsets.UTF_8.name()));
+                }
+                if (summary != null) {
+                    query.add(QUERY_SUMMARY + "=" + URLEncoder.encode(summary, StandardCharsets.UTF_8.name()));
+                }
+                if (description != null) {
+                    query.add(QUERY_DESCRIPTION + "=" + URLEncoder.encode(description, StandardCharsets.UTF_8.name()));
+                }
+            } catch (UnsupportedEncodingException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            return URI.create("xray://" + testClass.getName() + "?" + String.join("&", query));
+        }
+    }
+
+}


### PR DESCRIPTION
Related: https://github.com/Xray-App/xray-junit-extensions/issues/59

I'm still not 100% convinced that this is the correct use of `UriSource`, so I set PR as a draft.
Some links:

- [junit](https://junit.org/junit5/docs/current/user-guide/#writing-tests-dynamic-tests-uri-test-source) says about `TestSource`: "a representation of the source of a test or container used to navigate to its location by IDEs and build tools." - nothing specific, should be fine for us
- https://github.com/junit-team/junit5/issues/1178 - discussion on Cucumber's need to provide additional metadata in dynamic testing, resulted in https://github.com/junit-team/junit5/pull/1428

I used a custom scheme `xray://` to force not to use `FileSource` or `DirectorySource` - we need `DefaultUriSource` to not lose query data, see `UriSource#from(URI)` implementation.

Sample test class:
```java
package xyz;

import static org.junit.jupiter.api.DynamicTest.dynamicTest;

import app.getxray.xray.junit.customjunitxml.XrayURI;
import java.util.List;
import org.junit.jupiter.api.DynamicTest;
import org.junit.jupiter.api.TestFactory;

class DynTest {

  @TestFactory
  List<DynamicTest> something() {
    return List.of(
        dynamicTest("test 1",
            XrayURI.builder()
                .key("ABC-100")
                .summary("Summary 1")
                .description("description 1")
                .build(this.getClass()),
            () -> {
              // ...
            }),
        dynamicTest("test 2",
            XrayURI.builder()
                .key("ABC-200")
                .summary("Summary 2")
                .build(this.getClass()),
            () -> {
              // ...
            }),
        dynamicTest("test 3",
            XrayURI.builder()
                .key("ABC-300")
                // should we pass the dynamic test's display name "test 3" as summary to the report?
                .description("description 3")
                .build(this.getClass()),
            () -> {
              // ...
            })
    );
  }

}

```