### PR TITLE
Read tags in XrayTestMetadataReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ public class XrayEnabledTestExamples {
 ### Customizing how test metadata is read
 
 When generating the report, it's allowed to customize the way the test method information is read.
-By default, test information such as id, key, summary, description and requirements are read directly from @XrayTest and @Requirements annotations.
+By default, test information such as id, key, summary, description, requirements and labels are read directly from @XrayTest, @Requirements and JUnits @Tag annotations.
 This behavior can be overridden by the user when he wants to change the way these meta-information are generated, or when he wants to use their own annotations to describe the tests.
 
 To do this, you need to create a public class with a no-argument constructor that implements the `app.getxray.xray.junit.customjunitxml.XrayTestMetadataReader` interface (or extend `app.getxray.xray.junit.customjunitxml.DefaultXrayTestMetadataReader` class).
@@ -260,13 +260,60 @@ class SimpleTest {
 }
 ```
 
+#### Example: Custom test metadata reader to ignore JUnits @Tag annotation
+
+In case of using JUnit @Tag annotations in your tests, but you don't want these tags to be used as labels in Xray, 
+you can create a custom test metadata reader that ignores them.
+
+_CustomTestMetadataReader.java_
+```java
+package com.example;
+
+import app.getxray.xray.junit.customjunitxml.DefaultXrayTestMetadataReader;
+import org.junit.platform.launcher.TestIdentifier;
+
+import java.util.Optional;
+
+public class CustomTestMetadataReader extends DefaultXrayTestMetadataReader {
+
+    @Override
+    public List<String> getTags(TestIdentifier testIdentifier) {
+        return List.of(); // ignore JUnit @Tag annotations
+    }
+}
+```
+
+_xray-junit-extensions.properties_
+```
+test_metadata_reader=com.example.CustomTestMetadataReader
+```
+
+_SimpleTest.java_
+```java
+package com.example;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SimpleTest {
+
+    @Test
+    @Tag("hide me in Xray report")
+    @Tag("and me too")
+    @DisplayName("simple test")
+    void simpleTest() {
+        // ...
+    }
+}
+```
+
 ## Other features and limitations
 
 ### Name of Tests
 
 The summary of the Test issue will be set based on these rules (the first that applies):
 
-* based on the summary attribute of @XrayTest annotation (e.g. `@XrayTest(summary = "xxx")`); 
+* based on the summary attribute of @XrayTest annotation (e.g. `@XrayTest(summary = "xxx")`);
 * based on the `@DisplayName` annotation, or the display name of dynamically created tests from a TestFactory;
 * based on the test's method name.
 

--- a/src/main/java/app/getxray/xray/junit/customjunitxml/DefaultXrayTestMetadataReader.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/DefaultXrayTestMetadataReader.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestIdentifier;
 
@@ -24,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class DefaultXrayTestMetadataReader implements XrayTestMetadataReader {
 
@@ -78,6 +80,15 @@ public class DefaultXrayTestMetadataReader implements XrayTestMetadataReader {
                 .map(Requirement::value)
                 .map(arr -> Collections.unmodifiableList(Arrays.asList(arr)))
                 .orElse(Collections.emptyList());
+    }
+
+    @Override
+    public List<String> getTags(TestIdentifier testIdentifier) {
+        return testIdentifier.getTags()
+                .stream()
+                .map(TestTag::getName)
+                .map(String::trim)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
     }
 
     protected <A extends Annotation> Optional<A> getTestMethodAnnotation(TestIdentifier testIdentifier, Class<A> aClass) {

--- a/src/main/java/app/getxray/xray/junit/customjunitxml/XmlReportWriter.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/XmlReportWriter.java
@@ -297,8 +297,7 @@ class XmlReportWriter {
 			addProperty(writer, "test_summary", testSummaryOpt.get());
 		}
 
-		List<String> tags = testIdentifier.getTags().stream().map(TestTag::getName).map(String::trim)
-				.collect(Collectors.toList());
+		List<String> tags = xrayTestMetadataReader.getTags(testIdentifier);
 		if (!tags.isEmpty()) {
 			addProperty(writer, "tags", String.join(",", tags));
 		}

--- a/src/main/java/app/getxray/xray/junit/customjunitxml/XmlReportWriter.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/XmlReportWriter.java
@@ -15,7 +15,6 @@ import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
-import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestIdentifier;

--- a/src/main/java/app/getxray/xray/junit/customjunitxml/XrayTestMetadataReader.java
+++ b/src/main/java/app/getxray/xray/junit/customjunitxml/XrayTestMetadataReader.java
@@ -47,4 +47,9 @@ public interface XrayTestMetadataReader {
      */
     List<String> getRequirements(TestIdentifier testIdentifier);
 
+    /**
+     * @param testIdentifier test identifier
+     * @return Unmodifiable list of tags
+     */
+    List<String> getTags(TestIdentifier testIdentifier);
 }

--- a/src/test/java/app/getxray/xray/junit/customjunitxml/CustomXrayTestMetadataReader.java
+++ b/src/test/java/app/getxray/xray/junit/customjunitxml/CustomXrayTestMetadataReader.java
@@ -59,4 +59,9 @@ public class CustomXrayTestMetadataReader implements XrayTestMetadataReader {
     public List<String> getRequirements(TestIdentifier testIdentifier) {
         return Collections.emptyList();
     }
+
+    @Override
+    public List<String> getTags(TestIdentifier testIdentifier) {
+        return Collections.emptyList();
+    }
 }


### PR DESCRIPTION
## Summary
This pull request introduces changes to the way `@Tag` annotations are processed in the project, aligning the tag processing mechanism with the approach used for `@Requirement` annotations.

## Motivation
The previous implementation did not allow overriding or customizing how tags are processed. This change enables users to override tag processing, similar to how the `@Requirement` annotation can be customized. 

In my use case, `@Tag` annotations are already used in an extensive project for various technical reasons, but these should not be visible in XRay. The change proposed here allows the `@Tag` annotations to be handled accordingly via an customized implementation of `XrayTestMetadataReader` (as documented in _Customizing how test metadata is read_).

## Changes
Refactored tag extraction logic in `DefaultXrayTestMetadataReader` and `XmlReportWriter` to allow for extensibility and overriding, following the same pattern as used for `@Requirement` and `@DisplayName`.

This update introduces a breaking change due to modifications in the `XrayTestMetadataReader` interface. Users who have implemented or extended the previous interface for a custom `XrayTestMetadataReader` implementation need to update their code.