### PR TITLE
Add repository link in pom.xml to allow automatic fetching of changelogs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,10 @@
     <description>Improvements for JUnit that allow you to take better advantage of JUnit 5/6 (jupiter engine) whenever using it together with Xray Test Management.</description>
     <url>https://github.com/Xray-App/xray-junit-extensions</url>
   
+    <scm>
+      <url>https://github.com/Xray-App/xray-junit-extensions</url>
+    </scm>
+    
     <licenses>
       <license>
         <name>Eclipse Public License v2.0</name>


### PR DESCRIPTION
Dependency update tools like [Renovate](https://docs.renovatebot.com/) need the scm URL in the pom.xml file to be able to [automatically retrieve changelogs](https://docs.renovatebot.com/modules/datasource/maven/#making-your-changelogs-fetchable) for new releases.